### PR TITLE
Fix AmbiguousMatchException in .net5 app

### DIFF
--- a/src/Utilities/KnownReflectionDefinitions.cs
+++ b/src/Utilities/KnownReflectionDefinitions.cs
@@ -56,7 +56,7 @@ namespace ThriftSharp.Utilities
     internal static class Methods
     {
         public static readonly MethodInfo
-            Enum_IsDefined = typeof( Enum ).GetTypeInfo().GetDeclaredMethod( "IsDefined" ),
+            Enum_IsDefined = typeof( Enum ).GetTypeInfo().GetMethod( "IsDefined", new [] { typeof(Type), typeof(object) } ),
 
             ThriftStructReader_Skip = TypeInfos.ThriftStructReader.GetDeclaredMethod( "Skip" ),
 


### PR DESCRIPTION
When using ThriftSharp in a .net5 app, there is an exception:
```
System.TypeInitializationException: The type initializer for 'ThriftSharp.Utilities.Methods' threw an exception.
 ---> System.Reflection.AmbiguousMatchException: Ambiguous match found.
   at System.RuntimeType.GetMethodImplCommon(String name, Int32 genericParameterCount, BindingFlags bindingAttr, Binder binder, CallingConventions callConv, Type[] types, ParameterModifier[] modifiers)
   at System.RuntimeType.GetMethodImpl(String name, BindingFlags bindingAttr, Binder binder, CallingConventions callConv, Type[] types, ParameterModifier[] modifiers)
   at System.Type.GetMethod(String name, BindingFlags bindingAttr)
   at System.Reflection.TypeInfo.GetDeclaredMethod(String name)
   at ThriftSharp.Utilities.Methods..cctor()
```

This is caused by an overload method for Enum.IsDefined added in .net5.
See documentation here: https://docs.microsoft.com/en-us/dotnet/api/system.enum.isdefined?view=net-5.0.

With this simple fix, the correct method is picked and there is no more ambiguity.

Could you please merge this PR and publish a new version of the nuget package ?
Thanks!